### PR TITLE
Remove atty and just use IsTerminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,32 +12,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "dfang"
 version = "0.1.4"
 dependencies = [
- "atty",
  "lazy_static",
  "regex",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -45,12 +24,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "libc"
-version = "0.2.139"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "memchr"
@@ -79,29 +52,6 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 name = "rfang"
 version = "0.1.4"
 dependencies = [
- "atty",
  "lazy_static",
  "regex",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/dfang/Cargo.toml
+++ b/dfang/Cargo.toml
@@ -14,4 +14,3 @@ edition = "2021"
 [dependencies]
 regex = "1"
 lazy_static = "1"
-atty = "0.2.*"

--- a/dfang/src/main.rs
+++ b/dfang/src/main.rs
@@ -1,9 +1,7 @@
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::env;
-use std::io;
-use std::io::Read;
-extern crate atty;
+use std::io::{self, Read, IsTerminal};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -26,7 +24,7 @@ fn main() {
 
     if args.len() < 2 {
         let mut input = String::new();
-        if !atty::is(atty::Stream::Stdin) {
+        if !io::stdin().is_terminal() {
             // read input from pipe
             io::stdin().read_to_string(&mut input).unwrap();
             for line in input.lines() {

--- a/rfang/Cargo.toml
+++ b/rfang/Cargo.toml
@@ -14,4 +14,3 @@ edition = "2021"
 [dependencies]
 regex = "1"
 lazy_static = "1"
-atty = "0.2.*"

--- a/rfang/src/main.rs
+++ b/rfang/src/main.rs
@@ -1,9 +1,7 @@
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::env;
-use std::io;
-use std::io::Read;
-extern crate atty;
+use std::io::{self, Read, IsTerminal};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -21,7 +19,7 @@ fn main() {
 
     if args.len() < 2 {
         let mut input = String::new();
-        if !atty::is(atty::Stream::Stdin) {
+        if !io::stdin().is_terminal() {
             // read input from pipe
             io::stdin().read_to_string(&mut input).unwrap();
             for line in input.lines() {


### PR DESCRIPTION
`atty` is unmaintained, but we can just use the IsTerminal trait instead. This PR removes `atty` in lieu of the rust std lib.
