### PR TITLE
Drop the placeholder root binary that nothing builds

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}


### PR DESCRIPTION
Deletes the root `src/main.rs` hello-world. The root is a virtual workspace with no `[package]`, so `cargo metadata` confirms nothing ever built this file.

No effect on `dfang` or `rfang`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the default “Hello, world!” startup output.
  * The application no longer includes the previous placeholder entry point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->