### PR TITLE
Release 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,8 @@ version = 3
 
 [[package]]
 name = "dfang"
-version = "0.1.5"
+version = "0.2.0"
 
 [[package]]
 name = "rfang"
-version = "0.1.5"
+version = "0.2.0"

--- a/dfang/Cargo.toml
+++ b/dfang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dfang"
-version = "0.1.5"
+version = "0.2.0"
 authors = ["Patrick Tulskie <patricktulskie@gmail.com>"]
 license = "MIT"
 description = "A tool to defang IOCs."

--- a/rfang/Cargo.toml
+++ b/rfang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rfang"
-version = "0.1.5"
+version = "0.2.0"
 authors = ["Patrick Tulskie <patricktulskie@gmail.com>"]
 license = "MIT"
 description = "A tool to refang IOCs."


### PR DESCRIPTION
Version bump only — no code changes.

Minor rather than patch because defanging output changed for lines carrying more than one IOC (previously only the first matched kind was escaped).

Shipping in 0.2.0:
- zero external dependencies; `regex` and the unmaintained `lazy_static` are gone
- binary 1,602,080 → 302,864 bytes
- every IOC on a line is defanged, not just the first kind matched
- scheme case is preserved, so `HTTP://` round-trips back to `HTTP://`

`Cargo.lock` stays at format v3. Verified `build --locked` and `test --locked` (12 + 7 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `dfang` and `rfang` package versions from 0.1.5 to 0.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->