### PR TITLE
Attach prebuilt binaries to GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
         required: true
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -19,6 +19,8 @@ jobs:
   build:
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -48,10 +50,12 @@ jobs:
       - name: Package
         id: package
         shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+          TARGET: ${{ matrix.target }}
         run: |
-          version="${{ inputs.tag || github.ref_name }}"
-          name="dfang-${version}-${{ matrix.target }}"
-          bin="target/${{ matrix.target }}/release"
+          name="dfang-${RELEASE_TAG}-${TARGET}"
+          bin="target/${TARGET}/release"
           mkdir -p "dist/${name}"
           if [ "${{ runner.os }}" = "Windows" ]; then
             cp "${bin}/dfang.exe" "${bin}/rfang.exe" "dist/${name}/"
@@ -77,6 +81,8 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -88,11 +94,12 @@ jobs:
           merge-multiple: true
 
       - name: Checksums
-        run: cd dist && sha256sum * > SHA256SUMS
+        run: cd dist && sha256sum -- dfang-* > SHA256SUMS
 
       - name: Publish release
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
-          gh release create "${{ inputs.tag || github.ref_name }}" \
-            --verify-tag --generate-notes dist/*
+          gh release create "$RELEASE_TAG" \
+            --verify-tag --generate-notes dist/SHA256SUMS dist/dfang-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Release
+
+on:
+  push:
+    tags: [ "v*" ]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to build and release"
+        required: true
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Install target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --release --locked --target ${{ matrix.target }}
+
+      - name: Package
+        id: package
+        shell: bash
+        run: |
+          version="${{ inputs.tag || github.ref_name }}"
+          name="dfang-${version}-${{ matrix.target }}"
+          bin="target/${{ matrix.target }}/release"
+          mkdir -p "dist/${name}"
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            cp "${bin}/dfang.exe" "${bin}/rfang.exe" "dist/${name}/"
+          else
+            cp "${bin}/dfang" "${bin}/rfang" "dist/${name}/"
+          fi
+          cp README.md "dist/${name}/"
+          cd dist
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            7z a "${name}.zip" "${name}" > /dev/null
+            echo "asset=dist/${name}.zip" >> "$GITHUB_OUTPUT"
+          else
+            tar czf "${name}.tar.gz" "${name}"
+            echo "asset=dist/${name}.tar.gz" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.target }}
+          path: ${{ steps.package.outputs.asset }}
+          if-no-files-found: error
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: actions/download-artifact@v8
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Checksums
+        run: cd dist && sha256sum * > SHA256SUMS
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ inputs.tag || github.ref_name }}" \
+            --verify-tag --generate-notes dist/*


### PR DESCRIPTION
Releases have been source-only up to now. Pushing a `v*` tag will build binaries for five targets and attach them, so users can grab one instead of building.

All five build natively — no cross-compilation:

| target | runner |
|---|---|
| `aarch64-apple-darwin` | `macos-latest` |
| `x86_64-apple-darwin` | `macos-latest` |
| `x86_64-unknown-linux-gnu` | `ubuntu-latest` |
| `aarch64-unknown-linux-gnu` | `ubuntu-24.04-arm` |
| `x86_64-pc-windows-msvc` | `windows-latest` |

Each target produces a `.tar.gz` (`.zip` on Windows) containing both binaries plus the README. A final job collects them, writes `SHA256SUMS`, and creates the release with generated notes.

Verified locally for the native target: packaging script runs clean, archive is 283KB with the expected contents, binaries come out at 302,864 bytes (so the release profile does apply through `--target`), and a defang/refang round-trip works from the packaged build.

Action versions checked against the API rather than assumed — `checkout@v7`, `upload-artifact@v7`, `download-artifact@v8`, with every input confirmed present in those majors. Note this supersedes the "bump checkout to v5" item in #10, which is now out of date.

Builds use `--locked`. Includes a `workflow_dispatch` input for re-running against an existing tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated release publishing for macOS, Linux, and Windows.
  * Release packages now include platform-specific binaries, README files, and SHA-256 checksums.
  * GitHub releases can be created automatically from version tags or manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->