### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Dates are the crates.io publish dates. Entries before this file existed were
 reconstructed from the git history and the release tags.
 
-## Unreleased
+## 0.3.0 - 2026-08-09
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,86 @@
+# Changelog
+
+`dfang` and `rfang` are versioned and released together, so one entry covers both.
+
+Dates are the crates.io publish dates. Entries before this file existed were
+reconstructed from the git history and the release tags.
+
+## Unreleased
+
+### Added
+
+- `dfang` and `rfang` now ship a library alongside the binary, so `defang` and
+  `refang` can be called from Rust instead of shelled out to. Neither library
+  has dependencies and neither does any I/O.
+- `fang-conformance`, an unpublished workspace member holding one corpus of
+  defang/refang pairs asserted in both directions, so the two crates can't drift
+  apart on the tokens they exchange.
+
+### Changed
+
+- Readme documents the library entry points, and its code fences carry language
+  hints.
+
+## 0.2.0 - 2026-08-08
+
+### Added
+
+- Prebuilt binaries for macOS, Linux, and Windows attached to each release, so
+  installing no longer requires a Rust toolchain.
+
+### Changed
+
+- Every IOC on a line is defanged, not just the first kind matched. A line
+  carrying a URL and an email now comes out with both escaped.
+- A URL scheme keeps the case it arrived in, so `HTTP://` defangs to `HXXP://`
+  and refangs back to `HTTP://` rather than being lowercased along the way.
+
+### Removed
+
+- The `regex` and `lazy_static` dependencies, replaced with plain string
+  scanning. Both crates now build with no dependencies at all.
+- A placeholder root binary that nothing built.
+
+## 0.1.5 - 2023-11-16
+
+### Changed
+
+- Pipe detection uses `std::io::IsTerminal` instead of the unmaintained `atty`
+  crate.
+
+## 0.1.4 - 2023-01-30
+
+### Added
+
+- `--help` output shows the version.
+
+## 0.1.3 - 2023-01-30
+
+### Added
+
+- First round of tests.
+
+### Changed
+
+- Fewer allocations in the string replacement path.
+
+## 0.1.2 - 2023-01-27
+
+### Added
+
+- Input can be piped in from another command, so `pbpaste | dfang | pbcopy`
+  works.
+
+## 0.1.1 - 2023-01-25
+
+### Added
+
+- Multiple arguments in one invocation, each defanged on its own line.
+
+### Fixed
+
+- Argument handling that mishandled anything past the first input.
+
+## 0.1.0 - 2023-01-25
+
+Initial release of `dfang` and `rfang`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "dfang"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "fang-conformance"
@@ -16,4 +16,4 @@ dependencies = [
 
 [[package]]
 name = "rfang"
-version = "0.2.0"
+version = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@ For when you need to quickly make IOCs (email, urls, ip addresses) unclickable a
 
 ## Install
 
-```
+```shell
 cargo install dfang
 cargo install rfang
 ```
 
 ## Usage
 
-```
+```shell
 dfang something@somewhere.com
 rfang something[@]somewhere[.]com
 ```
 
 ...or pipe in from another application
 
-```
-// Extract defanged URLs from a file
+```shell
+# Extract defanged URLs from a file
 grep hxxp iocs.txt | rfang
 
-// Take your clipboard, defang it, and copy it again
+# Take your clipboard, defang it, and copy it again
 pbpaste | dfang | pbcopy
 ```
 
@@ -34,7 +34,7 @@ Both crates ship a library alongside the binary, so the string processing can be
 directly from Rust instead of shelling out. Neither has any dependencies and neither does
 any I/O.
 
-```
+```shell
 cargo add dfang
 cargo add rfang
 ```

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ rfang something[@]somewhere[.]com
 ...or pipe in from another application
 
 ```shell
-# Extract defanged URLs from a file
-grep hxxp iocs.txt | rfang
+# Extract and refang the defanged URLs in a file
+grep -i hxxp iocs.txt | rfang
 
 # Take your clipboard, defang it, and copy it again
 pbpaste | dfang | pbcopy

--- a/dfang/Cargo.toml
+++ b/dfang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dfang"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Patrick Tulskie <patricktulskie@gmail.com>"]
 license = "MIT"
 description = "A tool to defang IOCs."

--- a/rfang/Cargo.toml
+++ b/rfang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rfang"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Patrick Tulskie <patricktulskie@gmail.com>"]
 license = "MIT"
 description = "A tool to refang IOCs."


### PR DESCRIPTION
Docs and version bumps for 0.3.0. No behavior changes.

- Language hints on the readme code fences. Closes #17.
- A changelog, backfilled from the release tags and git history.
- `dfang` and `rfang` to 0.3.0.

0.3.0 is the release that ships the library targets and `fang-conformance` from #16.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Release**
  - Released `dfang` and `rfang` version 0.3.0.
  - Added a changelog covering releases from 0.1.0 through 0.3.0, including key features, improvements, and fixes.

- **Documentation**
  - Improved shell command examples with proper syntax highlighting and comment formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->