### PR TITLE
Lint the workflows themselves with actionlint and zizmor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag || github.ref }}
+          persist-credentials: false
 
       - name: Install target
         run: rustup target add ${{ matrix.target }}
@@ -87,6 +88,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag || github.ref }}
+          persist-credentials: false
 
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -1,0 +1,22 @@
+name: Workflows
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+    - name: actionlint
+      run: docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:1.7.12 -color
+    - name: zizmor
+      run: docker run --rm -v "$PWD":/repo:ro -w /repo ghcr.io/zizmorcore/zizmor:1.29.0 --no-online-audits .github/workflows/

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  lint:
+  lint-workflows:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # Every action here is first-party `actions/*`. A tag is enough; hash
+        # pinning would mean bumping a digest by hand on every release.
+        "*": ref-pin

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -2,6 +2,7 @@ rules:
   unpinned-uses:
     config:
       policies:
-        # Every action here is first-party `actions/*`. A tag is enough; hash
-        # pinning would mean bumping a digest by hand on every release.
-        "*": ref-pin
+        # First-party actions only. A tag is enough here; hash pinning would
+        # mean bumping a digest by hand on every release. Anything else keeps
+        # zizmor's default hash-pin requirement.
+        "actions/*": ref-pin


### PR DESCRIPTION
Last checkbox from #10 — the workflow-linting item added in the follow-up comment.

New `Workflows` workflow runs `actionlint` and `zizmor` over `.github/workflows/` on every push and PR, both as pinned containers so there's nothing to install on the runner. It lints itself too.

Getting zizmor to green needed two calls:

- **`artipacked` on `release.yml`** — added `persist-credentials: false` to both checkout steps, same as `rust.yml` got in #19. The release job authenticates through `GH_TOKEN` for `gh release create`, so nothing there wanted the persisted git credential.
- **`unpinned-uses`** — six `@vN` refs across both files, flagged high under zizmor's default hash-pin policy. `.github/zizmor.yml` sets the policy to `ref-pin` instead. Every action in this repo is first-party `actions/*`, and hash pinning means hand-bumping a digest on every release. Say the word if you'd rather pin digests and I'll switch it.

actionlint was already clean on all three files.

---
Written by Claude Opus 5 in Claude Code.