### PR TITLE
Document the Homebrew install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ reconstructed from the git history and the release tags.
 ### Changed
 
 - Both crates declare a minimum supported Rust version of 1.78, tested in CI.
+- Readme points at the Homebrew tap, which has carried a formula for both
+  binaries since 0.3.0.
 
 ## 0.3.0 - 2026-08-09
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ For when you need to quickly make IOCs (email, urls, ip addresses) unclickable a
 
 ## Install
 
+With Homebrew, on macOS or Linux:
+
+```shell
+brew tap PatrickTulskie/tap
+brew trust PatrickTulskie/tap
+brew install dfang
+```
+
+One formula carries both binaries. Homebrew 6 won't load a third-party tap until
+it's trusted, which is what the `brew trust` line is for.
+
+With cargo:
+
 ```shell
 cargo install dfang
 cargo install rfang


### PR DESCRIPTION
The readme only mentioned `cargo install`, so the Homebrew tap that has carried both binaries since 0.3.0 was undiscoverable.

```shell
brew tap PatrickTulskie/tap
brew trust PatrickTulskie/tap
brew install dfang
```

Readme change only — the formula in `PatrickTulskie/homebrew-tap` already does the work, and `rfang` is aliased to it.

The `brew trust` line is needed because Homebrew 6 refuses to load third-party taps without it. Verified the three commands on arm64 macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added instructions for installing `dfang` via Homebrew on macOS and Linux.
  - Clarified that the Homebrew formula includes both `dfang` and `rfang`.
  - Updated the unreleased changelog to reference the Homebrew tap and its available binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->