### PR TITLE
Buffer stdout on piped input and exit quietly on a broken pipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ reconstructed from the git history and the release tags.
 
 ### Changed
 
+- Piped input is written through a buffer instead of flushing stdout on every
+  line, which roughly doubles throughput on large inputs. Output is unchanged.
+- A downstream reader closing early (`dfang < iocs.txt | head -1`) now ends the
+  run quietly instead of panicking with a broken-pipe message.
 - Both crates declare a minimum supported Rust version of 1.78, tested in CI.
 - Readme points at the Homebrew tap, which has carried a formula for both
   binaries since 0.3.0.

--- a/dfang/src/main.rs
+++ b/dfang/src/main.rs
@@ -1,6 +1,10 @@
+// Explicit `return` is deliberate here; the lint would rewrite it.
+#![allow(clippy::needless_return)]
+
 use dfang::defang;
 use std::env;
-use std::io::{self, IsTerminal, Read};
+use std::io::{self, BufWriter, IsTerminal, Read, Write};
+use std::process;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -8,21 +12,35 @@ fn main() {
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 2 {
-        let mut input = String::new();
-        if !io::stdin().is_terminal() {
-            // read input from pipe
-            io::stdin().read_to_string(&mut input).unwrap();
-            for line in input.lines() {
-                println!("{}", defang(line));
-            }
-        } else {
+        if io::stdin().is_terminal() {
             help();
+        } else if let Err(err) = defang_stdin() {
+            // The reader hanging up (`dfang < big.txt | head -1`) is not an error.
+            if err.kind() == io::ErrorKind::BrokenPipe {
+                return;
+            }
+            eprintln!("dfang: {err}");
+            process::exit(1);
         }
     } else {
         for i in 1..args.len() {
             println!("{}", defang(&args[i]));
         }
     }
+}
+
+/// Buffered so stdout is flushed once per block rather than once per line;
+/// on big inputs the per-line flushes were most of the runtime.
+fn defang_stdin() -> io::Result<()> {
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input)?;
+
+    let mut out = BufWriter::new(io::stdout().lock());
+    for line in input.lines() {
+        writeln!(out, "{}", defang(line))?;
+    }
+
+    return out.flush();
 }
 
 fn help() {

--- a/dfang/tests/cli.rs
+++ b/dfang/tests/cli.rs
@@ -1,0 +1,51 @@
+// Explicit `return` is deliberate here; the lint would rewrite it.
+#![allow(clippy::needless_return)]
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run(input: &[u8]) -> std::process::Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_dfang"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.take().unwrap().write_all(input).unwrap();
+
+    return child.wait_with_output().unwrap();
+}
+
+#[test]
+fn defangs_every_piped_line() {
+    let output = run(b"http://a.com\nuser@b.org\n\n10.0.0.1");
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        "hxxp[://]a[.]com\nuser[@]b[.]org\n\n10[.]0[.]0[.]1\n"
+    );
+}
+
+/// A downstream reader that hangs up early (`dfang < big.txt | head -1`)
+/// should end the run quietly, not with a panic on stderr.
+#[test]
+fn exits_quietly_when_the_reader_hangs_up() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_dfang"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    drop(child.stdout.take());
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all("http://example.com\n".repeat(100_000).as_bytes())
+        .unwrap();
+
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+}

--- a/rfang/src/main.rs
+++ b/rfang/src/main.rs
@@ -1,6 +1,10 @@
+// Explicit `return` is deliberate here; the lint would rewrite it.
+#![allow(clippy::needless_return)]
+
 use rfang::refang;
 use std::env;
-use std::io::{self, IsTerminal, Read};
+use std::io::{self, BufWriter, IsTerminal, Read, Write};
+use std::process;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -8,21 +12,35 @@ fn main() {
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 2 {
-        let mut input = String::new();
-        if !io::stdin().is_terminal() {
-            // read input from pipe
-            io::stdin().read_to_string(&mut input).unwrap();
-            for line in input.lines() {
-                println!("{}", refang(line));
-            }
-        } else {
+        if io::stdin().is_terminal() {
             help();
+        } else if let Err(err) = refang_stdin() {
+            // The reader hanging up (`rfang < big.txt | head -1`) is not an error.
+            if err.kind() == io::ErrorKind::BrokenPipe {
+                return;
+            }
+            eprintln!("rfang: {err}");
+            process::exit(1);
         }
     } else {
         for i in 1..args.len() {
             println!("{}", refang(&args[i]));
         }
     }
+}
+
+/// Buffered so stdout is flushed once per block rather than once per line;
+/// on big inputs the per-line flushes were most of the runtime.
+fn refang_stdin() -> io::Result<()> {
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input)?;
+
+    let mut out = BufWriter::new(io::stdout().lock());
+    for line in input.lines() {
+        writeln!(out, "{}", refang(line))?;
+    }
+
+    return out.flush();
 }
 
 fn help() {

--- a/rfang/tests/cli.rs
+++ b/rfang/tests/cli.rs
@@ -1,0 +1,51 @@
+// Explicit `return` is deliberate here; the lint would rewrite it.
+#![allow(clippy::needless_return)]
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run(input: &[u8]) -> std::process::Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rfang"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.take().unwrap().write_all(input).unwrap();
+
+    return child.wait_with_output().unwrap();
+}
+
+#[test]
+fn refangs_every_piped_line() {
+    let output = run(b"hxxp[://]a[.]com\nuser[@]b[.]org\n\n10[.]0[.]0[.]1");
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        "http://a.com\nuser@b.org\n\n10.0.0.1\n"
+    );
+}
+
+/// A downstream reader that hangs up early (`rfang < big.txt | head -1`)
+/// should end the run quietly, not with a panic on stderr.
+#[test]
+fn exits_quietly_when_the_reader_hangs_up() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rfang"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    drop(child.stdout.take());
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all("http://example.com\n".repeat(100_000).as_bytes())
+        .unwrap();
+
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+}


### PR DESCRIPTION
Addresses #5.

The piped branch of both binaries now writes through a `BufWriter` with an explicit `flush()`, so stdout is flushed once per block instead of once per line. Output is byte-identical to the current binaries over a 400k-line corpus, in both directions.

| binary | main | this branch |
|---|---|---|
| `dfang` | 0.384s | 0.214s |
| `rfang` | 0.316s | 0.150s |

400k lines / 19.5 MB, M3 Ultra, mean of the fastest 8 of 12 runs.

Also in: a reader hanging up (`dfang < big.txt | head -1`) used to panic with `failed printing to stdout: Broken pipe` and exit 101. Now it exits 0 with nothing on stderr, same as ripgrep. Any other write error is reported on stderr with exit 1. Each crate gets an integration test on its binary for both paths.

**Left out: the `--line-buffered` flag.** Both binaries read stdin to EOF before writing anything, so the whole output phase happens after all input is in memory and takes at most a couple hundred milliseconds. Line buffering versus block buffering isn't observable to a downstream reader until the tool streams its input, and a flag can't be removed once it ships. If you want the flag anyway, or want streaming input first, say so and I'll follow up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changed**
  - Improved throughput when processing large amounts of piped input while preserving output.
  - `dfang` and `rfang` now handle downstream readers closing early—such as when used with `head`—quietly and successfully, without broken-pipe errors or panic messages.
  - Other input/output errors now produce a clear error message and unsuccessful exit instead of an abrupt panic.

- **Tests**
  - Added coverage for multi-line piped input and early downstream termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->