### PR TITLE
Stream stdin line by line, with --line-buffered to flush every line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@ reconstructed from the git history and the release tags.
 
 ## Unreleased
 
+### Added
+
+- `--line-buffered` flushes output after every line instead of every block,
+  for `tail -f` style input or an interactive reader downstream.
+
 ### Changed
 
+- Piped input is handled line by line as it arrives instead of being read to
+  the end first, so a `tail -f` can be piped in and memory is bounded by the
+  longest line rather than the whole input.
 - Piped input is written through a buffer instead of flushing stdout on every
   line, which roughly doubles throughput on large inputs. Output is unchanged.
 - A downstream reader closing early (`dfang < iocs.txt | head -1`) now ends the

--- a/README.md
+++ b/README.md
@@ -39,7 +39,14 @@ grep -i hxxp iocs.txt | rfang
 
 # Take your clipboard, defang it, and copy it again
 pbpaste | dfang | pbcopy
+
+# Defang a log as it grows
+tail -f app.log | dfang --line-buffered
 ```
+
+Piped input is handled line by line as it arrives. Output is flushed in blocks,
+which is fastest for big files; `--line-buffered` flushes after every line for
+when the input trickles in or the next thing in the pipeline is interactive.
 
 ## Use as a library
 

--- a/dfang/src/main.rs
+++ b/dfang/src/main.rs
@@ -3,18 +3,20 @@
 
 use dfang::defang;
 use std::env;
-use std::io::{self, BufWriter, IsTerminal, Read, Write};
+use std::io::{self, BufRead, BufWriter, IsTerminal, Write};
 use std::process;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
+    let mut args: Vec<String> = env::args().skip(1).collect();
+    let line_buffered = args.iter().any(|a| a == "--line-buffered");
+    args.retain(|a| a != "--line-buffered");
 
-    if args.len() < 2 {
+    if args.is_empty() {
         if io::stdin().is_terminal() {
             help();
-        } else if let Err(err) = defang_stdin() {
+        } else if let Err(err) = defang_stdin(line_buffered) {
             // The reader hanging up (`dfang < big.txt | head -1`) is not an error.
             if err.kind() == io::ErrorKind::BrokenPipe {
                 return;
@@ -23,21 +25,27 @@ fn main() {
             process::exit(1);
         }
     } else {
-        for i in 1..args.len() {
-            println!("{}", defang(&args[i]));
+        for arg in &args {
+            println!("{}", defang(arg));
         }
     }
 }
 
-/// Buffered so stdout is flushed once per block rather than once per line;
-/// on big inputs the per-line flushes were most of the runtime.
-fn defang_stdin() -> io::Result<()> {
-    let mut input = String::new();
-    io::stdin().read_to_string(&mut input)?;
-
+/// Lines are handled as they arrive, so a `tail -f` can be piped in and memory
+/// is bounded by the longest line. Output is flushed once per block, or once
+/// per line when asked, since a block can sit unseen while the input is slow.
+fn defang_stdin(line_buffered: bool) -> io::Result<()> {
+    let mut input = io::stdin().lock();
     let mut out = BufWriter::new(io::stdout().lock());
-    for line in input.lines() {
-        writeln!(out, "{}", defang(line))?;
+    let mut line = String::new();
+
+    while input.read_line(&mut line)? > 0 {
+        // Same terminator handling as `str::lines`, so output is unchanged.
+        writeln!(out, "{}", defang(line.lines().next().unwrap_or("")))?;
+        if line_buffered {
+            out.flush()?;
+        }
+        line.clear();
     }
 
     return out.flush();
@@ -45,5 +53,8 @@ fn defang_stdin() -> io::Result<()> {
 
 fn help() {
     println!("dfang v{}", VERSION);
-    println!("usage: dfang <string>");
+    println!("usage: dfang <string>...");
+    println!("       dfang [--line-buffered] < input");
+    println!();
+    println!("  --line-buffered  flush after every line instead of every block");
 }

--- a/dfang/tests/cli.rs
+++ b/dfang/tests/cli.rs
@@ -1,25 +1,33 @@
 // Explicit `return` is deliberate here; the lint would rewrite it.
 #![allow(clippy::needless_return)]
 
-use std::io::Write;
-use std::process::{Command, Stdio};
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
 
-fn run(input: &[u8]) -> std::process::Output {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_dfang"))
+fn spawn(args: &[&str]) -> Child {
+    return Command::new(env!("CARGO_BIN_EXE_dfang"))
+        .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .unwrap();
-    child.stdin.take().unwrap().write_all(input).unwrap();
-
-    return child.wait_with_output().unwrap();
 }
 
 #[test]
 fn defangs_every_piped_line() {
-    let output = run(b"http://a.com\nuser@b.org\n\n10.0.0.1");
+    let mut child = spawn(&[]);
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"http://a.com\r\nuser@b.org\n\n10.0.0.1")
+        .unwrap();
 
+    let output = child.wait_with_output().unwrap();
     assert!(output.status.success());
     assert_eq!(
         String::from_utf8(output.stdout).unwrap(),
@@ -27,23 +35,42 @@ fn defangs_every_piped_line() {
     );
 }
 
+/// Input is handled as it arrives, so a line comes back before stdin closes.
+/// Without `--line-buffered` it would sit in the output buffer instead.
+#[test]
+fn streams_each_line_as_it_arrives() {
+    let mut child = spawn(&["--line-buffered"]);
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+    stdin.write_all(b"http://a.com\n").unwrap();
+
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut line = String::new();
+        stdout.read_line(&mut line).unwrap();
+        tx.send(line).unwrap();
+    });
+    let line = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("no output before stdin was closed");
+    assert_eq!(line, "hxxp[://]a[.]com\n");
+
+    drop(stdin);
+    assert!(child.wait().unwrap().success());
+}
+
 /// A downstream reader that hangs up early (`dfang < big.txt | head -1`)
 /// should end the run quietly, not with a panic on stderr.
 #[test]
 fn exits_quietly_when_the_reader_hangs_up() {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_dfang"))
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .unwrap();
+    let mut child = spawn(&[]);
     drop(child.stdout.take());
-    child
+    // The binary exits partway through this write, so it may fail too.
+    let _ = child
         .stdin
         .take()
         .unwrap()
-        .write_all("http://example.com\n".repeat(100_000).as_bytes())
-        .unwrap();
+        .write_all("http://example.com\n".repeat(100_000).as_bytes());
 
     let output = child.wait_with_output().unwrap();
     assert!(output.status.success());

--- a/rfang/src/main.rs
+++ b/rfang/src/main.rs
@@ -3,18 +3,20 @@
 
 use rfang::refang;
 use std::env;
-use std::io::{self, BufWriter, IsTerminal, Read, Write};
+use std::io::{self, BufRead, BufWriter, IsTerminal, Write};
 use std::process;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
+    let mut args: Vec<String> = env::args().skip(1).collect();
+    let line_buffered = args.iter().any(|a| a == "--line-buffered");
+    args.retain(|a| a != "--line-buffered");
 
-    if args.len() < 2 {
+    if args.is_empty() {
         if io::stdin().is_terminal() {
             help();
-        } else if let Err(err) = refang_stdin() {
+        } else if let Err(err) = refang_stdin(line_buffered) {
             // The reader hanging up (`rfang < big.txt | head -1`) is not an error.
             if err.kind() == io::ErrorKind::BrokenPipe {
                 return;
@@ -23,21 +25,27 @@ fn main() {
             process::exit(1);
         }
     } else {
-        for i in 1..args.len() {
-            println!("{}", refang(&args[i]));
+        for arg in &args {
+            println!("{}", refang(arg));
         }
     }
 }
 
-/// Buffered so stdout is flushed once per block rather than once per line;
-/// on big inputs the per-line flushes were most of the runtime.
-fn refang_stdin() -> io::Result<()> {
-    let mut input = String::new();
-    io::stdin().read_to_string(&mut input)?;
-
+/// Lines are handled as they arrive, so a `tail -f` can be piped in and memory
+/// is bounded by the longest line. Output is flushed once per block, or once
+/// per line when asked, since a block can sit unseen while the input is slow.
+fn refang_stdin(line_buffered: bool) -> io::Result<()> {
+    let mut input = io::stdin().lock();
     let mut out = BufWriter::new(io::stdout().lock());
-    for line in input.lines() {
-        writeln!(out, "{}", refang(line))?;
+    let mut line = String::new();
+
+    while input.read_line(&mut line)? > 0 {
+        // Same terminator handling as `str::lines`, so output is unchanged.
+        writeln!(out, "{}", refang(line.lines().next().unwrap_or("")))?;
+        if line_buffered {
+            out.flush()?;
+        }
+        line.clear();
     }
 
     return out.flush();
@@ -45,5 +53,8 @@ fn refang_stdin() -> io::Result<()> {
 
 fn help() {
     println!("rfang v{}", VERSION);
-    println!("usage: rfang <string>");
+    println!("usage: rfang <string>...");
+    println!("       rfang [--line-buffered] < input");
+    println!();
+    println!("  --line-buffered  flush after every line instead of every block");
 }

--- a/rfang/tests/cli.rs
+++ b/rfang/tests/cli.rs
@@ -1,25 +1,33 @@
 // Explicit `return` is deliberate here; the lint would rewrite it.
 #![allow(clippy::needless_return)]
 
-use std::io::Write;
-use std::process::{Command, Stdio};
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
 
-fn run(input: &[u8]) -> std::process::Output {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_rfang"))
+fn spawn(args: &[&str]) -> Child {
+    return Command::new(env!("CARGO_BIN_EXE_rfang"))
+        .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .unwrap();
-    child.stdin.take().unwrap().write_all(input).unwrap();
-
-    return child.wait_with_output().unwrap();
 }
 
 #[test]
 fn refangs_every_piped_line() {
-    let output = run(b"hxxp[://]a[.]com\nuser[@]b[.]org\n\n10[.]0[.]0[.]1");
+    let mut child = spawn(&[]);
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"hxxp[://]a[.]com\r\nuser[@]b[.]org\n\n10[.]0[.]0[.]1")
+        .unwrap();
 
+    let output = child.wait_with_output().unwrap();
     assert!(output.status.success());
     assert_eq!(
         String::from_utf8(output.stdout).unwrap(),
@@ -27,23 +35,42 @@ fn refangs_every_piped_line() {
     );
 }
 
+/// Input is handled as it arrives, so a line comes back before stdin closes.
+/// Without `--line-buffered` it would sit in the output buffer instead.
+#[test]
+fn streams_each_line_as_it_arrives() {
+    let mut child = spawn(&["--line-buffered"]);
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+    stdin.write_all(b"hxxp[://]a[.]com\n").unwrap();
+
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut line = String::new();
+        stdout.read_line(&mut line).unwrap();
+        tx.send(line).unwrap();
+    });
+    let line = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("no output before stdin was closed");
+    assert_eq!(line, "http://a.com\n");
+
+    drop(stdin);
+    assert!(child.wait().unwrap().success());
+}
+
 /// A downstream reader that hangs up early (`rfang < big.txt | head -1`)
 /// should end the run quietly, not with a panic on stderr.
 #[test]
 fn exits_quietly_when_the_reader_hangs_up() {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_rfang"))
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .unwrap();
+    let mut child = spawn(&[]);
     drop(child.stdout.take());
-    child
+    // The binary exits partway through this write, so it may fail too.
+    let _ = child
         .stdin
         .take()
         .unwrap()
-        .write_all("http://example.com\n".repeat(100_000).as_bytes())
-        .unwrap();
+        .write_all("hxxp[://]example[.]com\n".repeat(100_000).as_bytes());
 
     let output = child.wait_with_output().unwrap();
     assert!(output.status.success());


### PR DESCRIPTION
Closes #5. Follow-up to #22.

Both binaries read stdin to EOF before writing anything, so `tail -f app.log | dfang` blocked until tail exited and `yes http://x.com | dfang` grew until it was killed. Now each line is handled as it arrives, through the buffered writer from #22, so memory is bounded by the longest line.

`--line-buffered` (grep spelling) flushes after every line, for input that trickles in or an interactive reader downstream. It's the flag from #5, which only became meaningful once input streams. Parsing is the minimum: the flag is picked out of argv wherever it sits, and anything left is defanged as before.

```shell
tail -f app.log | dfang --line-buffered
```

Verified:

- Output byte-identical to main over the 400k-line corpus, both directions, with and without the flag. Also on a corpus of `\r\n`, bare `\r`, empty lines, and a trailing `\r` without newline, since `read_line` and `str::lines` split differently.
- Throughput unchanged from #22 (dfang 0.21s, rfang 0.15s on 400k lines).
- Broken pipe still exits 0 quietly. Invalid UTF-8 now fails at the offending line with earlier output already written, exit 1.
- New integration test proves a line comes back before stdin closes.

Readme and changelog updated. No version bump; leaving that for 0.4.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--line-buffered` option to flush transformed output after each line.
  * Piped input is now processed incrementally, reducing memory usage and supporting streaming input.
  * Added support for multiple positional command-line arguments.
  * Updated help text with the new usage options.

* **Documentation**
  * Added examples and guidance for processing live or gradually arriving log input.

* **Tests**
  * Added coverage for line-by-line streaming, CRLF input normalization, and early process output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->